### PR TITLE
Fixed blinking marker bug

### DIFF
--- a/frontend/src/components/CustomMarker.tsx
+++ b/frontend/src/components/CustomMarker.tsx
@@ -7,7 +7,7 @@ import { useCustomFonts } from '../hooks/useCustomFonts';
 export const CustomMarker: React.FC<any> = ({ coordinate, onPress, text }) => {
 	useCustomFonts();
 	return (
-		<Marker coordinate={coordinate} onPress={onPress}>
+		<Marker coordinate={coordinate} onPress={onPress} tracksViewChanges={false}>
 			<View style={styles.container}>
 				<Text style={styles.text}>{text}</Text>
 			</View>


### PR DESCRIPTION
Resolves #60.

**_What:_**
Resolved the issue where markers on the map were flickering without user interaction by setting tracksViewChanges to false in the custom marker component.

**_Why:_**
The flickering was due to the markers continuously tracking changes to their child views. Disabling this tracking improves performance by preventing unnecessary re-renders after the first render pass. This solution was inspired by a suggestion from a related GitHub issue: [react-native-maps #3098](https://github.com/react-native-maps/react-native-maps/issues/3098).

**_How:_**
Added `tracksViewChanges={false}` to the custom marker component to stop tracking changes to child views after the initial render pass. This prevents the markers from flickering by eliminating the redundant updates.