### PR TITLE
Fixed search bar not clearing after a query

### DIFF
--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
 	View,
-	StyleSheet, Pressable,
+	StyleSheet
 } from 'react-native';
 import { Searchbar } from 'react-native-paper';
 import { MenuIcon } from './MenuIcon';
@@ -18,7 +18,7 @@ type TopBarProps = {
 
 
 const TopBar: React.FC<TopBarProps> = ({ navigation }) => {
-	const { state, setSearchType, setRegion } = useSearchContext();
+	const { setSearchType, setRegion } = useSearchContext();
 	const routeName = navigation.getState().routes[navigation.getState().index].name;
 	const [searchQuery, setSearchQuery] = React.useState('');
 
@@ -31,6 +31,7 @@ const TopBar: React.FC<TopBarProps> = ({ navigation }) => {
 			getCoordinatesFromAddress(searchQuery)
 				.then(region => {
 					setRegion(region);
+					setSearchQuery('');
 				})
 				.catch(error => {
 					console.error('Geocoding error:', error);


### PR DESCRIPTION
**_What:_**

Resolved the issue where the search query remained in the search bar indefinitely after a successful search by setting the search query to an empty string upon a successful search. Additionally, ensured that the search query remains in the search bar if the search is unsuccessful.

**_Why:_**

Previously, the search query would remain in the search bar even after a successful search, causing confusion for users, especially if they moved to a different area on the map (the search query they were seeing was no longer relevant to their current position).

Retaining the search query after an unsuccessful search allows users to correct their input without retyping, so this didn't need fixing.

**_How:_**
- Updated the `handleSearchQuery`function to clear the search query state upon a successful geocoding response.
- Ensured the search query is retained if the geocoding response indicates an error.

**_Steps to Verify:_**
- Enter a search query in the search bar.
- Perform the search.
- Verify that the search query is cleared from the search bar upon a successful search.
- Enter an incorrect search query and perform the search.
- Verify that the search query remains in the search bar after an unsuccessful search.

Closes #62.